### PR TITLE
Adapt to damaged rects

### DIFF
--- a/docs/polyfill.md
+++ b/docs/polyfill.md
@@ -72,8 +72,22 @@ For more info on nested containers, see [Nested Containers](../README.md#nested-
 
 ## Debug Mode
 
-You can set a global `ctDebug` flag to true in order to see paint rectangles from the collection of paints when a container has updated.
-(set `window.ctDebug` or `globalThis.ctDebug` to true)
+You can set a global `ctDebug` flag to true in order to see paint rectangles from the collection of paints when a container has updated. This will work only when using the polyfill and not the native implementation.
+(set `window.ctDebug` or `globalThis.ctDebug` to true).
+
+In case you want to handle directly the painting of the rectangles, you can use directly the API provided by the polyfill,
+`ContainerPerformanceObserver.paintDebugOverlay(rects)`.
+
+An example:
+```js
+const nativeObserver = new PerformanceObserver((v) => {
+  const entries = v.getEntries();
+  entries.forEach((entry) => {
+    const rects = entry?.damagedRects;
+    ContainerPerformanceObserver.paintDebugOverlay(rects);
+  });
+});
+```
 
 ## Performance Impact of a native implementation
 

--- a/examples/adding-content/index.js
+++ b/examples/adding-content/index.js
@@ -1,10 +1,14 @@
-window.ctDebug = true;
 const queryString = window.location.search;
 const urlParams = new URLSearchParams(window.location.search);
 const nestedStrategy = urlParams.get("nestedStrategy") || "ignore"
 
 const nativeObserver = new PerformanceObserver((v) => {
-  console.log(v.getEntries());
+  const entries = v.getEntries();
+  console.log(entries);
+  entries.forEach((entry) => {
+    const rects = entry?.damagedRects;
+    ContainerPerformanceObserver.paintDebugOverlay(rects);
+  });
 });
 
 nativeObserver.observe({ type: "container", nestedStrategy: nestedStrategy });

--- a/examples/table/index.js
+++ b/examples/table/index.js
@@ -1,7 +1,8 @@
-window.ctDebug = true;
 const observer = new PerformanceObserver((list) => {
   list.getEntries().forEach((entry) => {
     console.log(entry);
+    const rects = entry.damagedRects;
+    ContainerPerformanceObserver.paintDebugOverlay(rects);
   });
 });
 

--- a/polyfill/polyfill.ts
+++ b/polyfill/polyfill.ts
@@ -239,7 +239,7 @@ class ContainerPerformanceObserver implements PerformanceObserver {
       divCol.add(div);
     };
 
-    if (rectData instanceof Set) {
+    if ((rectData instanceof Set) || (Array.isArray(rectData))) {
       rectData?.forEach((rect) => {
         addOverlayToRect(rect);
       });

--- a/polyfill/polyfill.ts
+++ b/polyfill/polyfill.ts
@@ -234,6 +234,7 @@ class ContainerPerformanceObserver implements PerformanceObserver {
       div.style.left = `${rectData.left}px`;
       div.style.position = "absolute";
       div.style.transition = "background-color 1s";
+      div.setAttribute("containertiming-ignore", '');
       document.body.appendChild(div);
       divCol.add(div);
     };


### PR DESCRIPTION
Added to the container timing entries a new field damagedRects, that overseeds the internal
paintedRect tracking implementation in the polyfill for debug mode. A similar change
has been added to the experimental Chromium implementation.

With this, we can move painting the overlays to the clients. So the tests are updated
accordingly. Now, the paint overlay is supported both with polyfill and with the native
implementation.