### PR TITLE
change casing of containertiming-ignore

### DIFF
--- a/ORIGIN_TRIAL.md
+++ b/ORIGIN_TRIAL.md
@@ -42,13 +42,13 @@ Mark a container element with the `containertiming` attribute and observe perfor
 
 ### Ignoring Parts of the Container
 
-Use the `containertiming-ignore` attribute to exclude specific subtrees from tracking:
+Use the `containertimingignore` attribute to exclude specific subtrees from tracking:
 
 ```html
 <div containertiming="main-content">
   <main>...</main>
   <!-- This aside and its children will be ignored -->
-  <aside containertiming-ignore>...</aside>
+  <aside containertimingignore>...</aside>
 </div>
 ```
 
@@ -114,7 +114,7 @@ To test the Container Timing API locally in Chrome:
 1. **Set attributes early**: Add the `containertiming` attribute before the element is added to the document for complete tracking
 2. **Use meaningful identifiers**: Choose descriptive names for the `containertiming` attribute to make analytics easier
 3. **Strategic placement**: Apply `containertiming` to semantic sections that matter for your metrics (e.g., "hero-section", "product-grid", "checkout-form")
-4. **Ignore irrelevant content**: Use `containertiming-ignore` on ads, analytics scripts, or decorative elements that shouldn't affect your component metrics
+4. **Ignore irrelevant content**: Use `containertimingignore` on ads, analytics scripts, or decorative elements that shouldn't affect your component metrics
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ We now describe precisely what information is exposed via the WebPerf API. The P
 
 ### Ignoring parts of the DOM
 
-If you want wish to ignore parts of the DOM tree you are monitoring, you can add the `containertiming-ignore` attribute to the element you want to ignore (plus its children).
+If you want wish to ignore parts of the DOM tree you are monitoring, you can add the `containertimingignore` attribute to the element you want to ignore (plus its children).
 
 ```html
 <div … containertiming="foobar">
   <main>...</main>
   <!-- We don't want to track paint udpates in the aside -->
-  <aside containertiming-ignore>...</aside>
+  <aside containertimingignore>...</aside>
 </div>
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -92,13 +92,13 @@ Ignoring Subtrees {#ignoring-subtrees}
 ---------------------------------------
 
 <div class="example">
-Parts of the DOM tree can be ignored using the <{{containertiming-ignore}}> attribute:
+Parts of the DOM tree can be ignored using the <{{containertimingignore}}> attribute:
 
 ```html
 <div containertiming="foobar">
   <main>...</main>
   <!-- Aside updates won't trigger container timing events -->
-  <aside containertiming-ignore>...</aside>
+  <aside containertimingignore>...</aside>
 </div>
 ```
 </div>
@@ -108,7 +108,7 @@ Terminology {#terminology}
 
 A <dfn export>container root</dfn> is an {{Element}} that has the {{containertiming}} attribute.
 
-An <dfn export>ignored subtree</dfn> is a subtree rooted at an {{Element}} with the {{containertiming-ignore}}> attribute.
+An <dfn export>ignored subtree</dfn> is a subtree rooted at an {{Element}} with the {{containertimingignore}}> attribute.
 
 A <dfn export>painted region</dfn> is a region (collection of rectangles) representing all the painted portions of a [=container root=] accumulated since it was first observed.
 
@@ -197,7 +197,7 @@ partial interface Element {
 <div dfn-for="Element">
 The <dfn attribute>containertiming</dfn> attribute is a {{DOMString}} that identifies the element as a [=container root=]. The value becomes the {{PerformanceContainerTiming/identifier}} in the corresponding {{PerformanceContainerTiming}} entry.
 
-The <dfn attribute>containertiming-ignore</dfn> attribute, when present, marks the element and its descendants as an [=ignored subtree=] that should not contribute to container timing measurements for ancestor [=container roots=].
+The <dfn attribute>containertimingignore</dfn> attribute, when present, marks the element and its descendants as an [=ignored subtree=] that should not contribute to container timing measurements for ancestor [=container roots=].
 </div>
 
 Container Timing Record {#container-timing-record}
@@ -322,7 +322,7 @@ To <dfn>maybe update the last new painted area</dfn> for a [=Container Timing Re
 4. Set |record|'s [=Container Timing Record/lastNewPaintedAreaPaintTimingInfo=] to |paintTimingInfo|.
 5. Set |record|'s [=Container Timing Record/lastNewPaintedAreaElement=] to |element|.
 6. Set |record|'s [=Container Timing Record/hasPendingChanges=] to true.
-7. If |containerRoot|'s [^containertiming-ignore^] content attribute is present, return.
+7. If |containerRoot|'s [^containertimingignore^] content attribute is present, return.
 8. Let |parentContainerRoot| be the result of <a>get the parent container root element</a> given |containerRoot|.
 9. If |parentContainerRoot| is null, return.
 10. Let |parentRecord| be the entry in |document|'s <a>container root records map</a> for |parentContainerRoot|. If no such entry exists, set |parentRecord| to the result of <a>create a Container Timing Record</a> given |paintTimingInfo| and the value of |parentContainerRoot|'s [^containertiming^] content attribute; then add (|parentContainerRoot| → |parentRecord|) to |document|'s <a>container root records map</a>.


### PR DESCRIPTION
dashes in html attributes are [not recommended](https://www.w3.org/TR/design-principles/#casing-rules), we should remove the dash and instead have `containertimingignore` instead

fixes https://github.com/WICG/container-timing/issues/35